### PR TITLE
Add async-await to feed cog

### DIFF
--- a/feed/__init__.py
+++ b/feed/__init__.py
@@ -1,5 +1,5 @@
 from .feed import ClassicBnetFeed
 
-def setup(bot):
-    bot.add_cog(ClassicBnetFeed(bot))
+async def setup(bot):
+    await bot.add_cog(ClassicBnetFeed(bot))
 


### PR DESCRIPTION
Fixes the following problem:

```
Jan 06 22:53:59 redacted.example.com bash[2214336]: /home/redbot/.local/share/Red-DiscordBot/data/classicbnet/cogs/CogManager/cogs/feed/__init__.py:4: RuntimeWarning: coroutine 'Red.add_cog' was never awaited
Jan 06 22:53:59 redacted.example.com bash[2214336]:   bot.add_cog(ClassicBnetFeed(bot))
Jan 06 22:53:59 redacted.example.com bash[2214336]: RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Jan 06 22:53:59 redacted.example.com bash[2214336]: [2024-01-06 22:53:59] [ERROR] red: Package loading failed
Jan 06 22:53:59 redacted.example.com bash[2214336]: Traceback (most recent call last):
Jan 06 22:53:59 redacted.example.com bash[2214336]:   File "/home/redbot/.local/lib/python3.11/site-packages/redbot/core/core_commands.py", line 188, in _load
Jan 06 22:53:59 redacted.example.com bash[2214336]:     await bot.load_extension(spec)
Jan 06 22:53:59 redacted.example.com bash[2214336]:   File "/home/redbot/.local/lib/python3.11/site-packages/redbot/core/bot.py", line 1686, in load_extension
Jan 06 22:53:59 redacted.example.com bash[2214336]:     await lib.setup(self)
Jan 06 22:53:59 redacted.example.com bash[2214336]: TypeError: object NoneType can't be used in 'await' expression 
```